### PR TITLE
Add license headers to all source files

### DIFF
--- a/examples/SimpleBlinker/SimpleBlinker.ino
+++ b/examples/SimpleBlinker/SimpleBlinker.ino
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 the BarePoller authors
+// This file is part of BarePoller, licensed under the MIT License. See LICENSE file for details.
+
 // Include the main library header
 #include <BarePoller.h>
 

--- a/src/ArduinoPlat.cpp
+++ b/src/ArduinoPlat.cpp
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 the BarePoller authors
+// This file is part of BarePoller, licensed under the MIT License. See LICENSE file for details.
+
 #include "ArduinoPlat.h"
 // Arduino.h is already included in ArduinoPlat.h
 

--- a/src/ArduinoPlat.h
+++ b/src/ArduinoPlat.h
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 the BarePoller authors
+// This file is part of BarePoller, licensed under the MIT License. See LICENSE file for details.
+
 #ifndef ARDUINOPLAT_H
 #define ARDUINOPLAT_H
 

--- a/src/BarePoller.h
+++ b/src/BarePoller.h
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 the BarePoller authors
+// This file is part of BarePoller, licensed under the MIT License. See LICENSE file for details.
+
 #ifndef BAREPOLLER_H
 #define BAREPOLLER_H
 

--- a/src/Blinker.cpp
+++ b/src/Blinker.cpp
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 the BarePoller authors
+// This file is part of BarePoller, licensed under the MIT License. See LICENSE file for details.
+
 #include "Blinker.h"
 // #include "Armed.h" // Removed missing include
 // #include "io_defs.h" // Removed project-specific include

--- a/src/Blinker.h
+++ b/src/Blinker.h
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 the BarePoller authors
+// This file is part of BarePoller, licensed under the MIT License. See LICENSE file for details.
+
 #ifndef BLINKER_H
 #define BLINKER_H
 

--- a/src/Platform.h
+++ b/src/Platform.h
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 the BarePoller authors
+// This file is part of BarePoller, licensed under the MIT License. See LICENSE file for details.
+
 #ifndef PLATFORM_H
 #define PLATFORM_H
 

--- a/src/PrecisionTimer.cpp
+++ b/src/PrecisionTimer.cpp
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 the BarePoller authors
+// This file is part of BarePoller, licensed under the MIT License. See LICENSE file for details.
+
 #include "PrecisionTimer.h"
 
 PrecisionTimer::PrecisionTimer(Platform* plat, unsigned long timeout):m_plat(plat), m_timeStart(0), m_timeElapsed(0), m_timeout(timeout), m_active(false)

--- a/src/PrecisionTimer.h
+++ b/src/PrecisionTimer.h
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 the BarePoller authors
+// This file is part of BarePoller, licensed under the MIT License. See LICENSE file for details.
+
 #ifndef PRECISIONTIMER_H
 #define PRECISIONTIMER_H
 

--- a/src/Switch.cpp
+++ b/src/Switch.cpp
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 the BarePoller authors
+// This file is part of BarePoller, licensed under the MIT License. See LICENSE file for details.
+
 #include "Switch.h"
 // const int DEBOUNCE_PERIOD = 0; //us // Made this a constructor argument with default 0
 

--- a/src/Switch.h
+++ b/src/Switch.h
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 the BarePoller authors
+// This file is part of BarePoller, licensed under the MIT License. See LICENSE file for details.
+
 #ifndef SWITCH_H
 #define SWITCH_H
 

--- a/src/X86Platform.cpp
+++ b/src/X86Platform.cpp
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 the BarePoller authors
+// This file is part of BarePoller, licensed under the MIT License. See LICENSE file for details.
+
 #include "X86Platform.h"
 #ifdef X86_PLAT
 

--- a/src/X86Platform.h
+++ b/src/X86Platform.h
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 the BarePoller authors
+// This file is part of BarePoller, licensed under the MIT License. See LICENSE file for details.
+
 #ifndef X86PLATFORM_H
 #define X86PLATFORM_H
 

--- a/src/io_defs.h
+++ b/src/io_defs.h
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 the BarePoller authors
+// This file is part of BarePoller, licensed under the MIT License. See LICENSE file for details.
+
 #ifndef IO_DEFS
 #define IO_DEFS
 


### PR DESCRIPTION
This commit adds the following SPDX license header to all .h, .cpp, and .ino files:

// SPDX-License-Identifier: MIT
// Copyright (c) 2025 the BarePoller authors
// This file is part of BarePoller, licensed under the MIT License. See LICENSE file for details.